### PR TITLE
Docker exec in image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.minimesos/
+
 *.class
 
 # IDEA files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
-FROM ubuntu:14.04
+FROM containersol/jre8-docker:v0.0.1
+
 MAINTAINER Container Solutions BV <info@container-solutions.com>
-
-ENV VERSION "feature/docker-machine"
-
-RUN echo "deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main" > /etc/apt/sources.list.d/openjdk.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 86F44E2A && \
-    apt-get update && \
-    apt-get -y --no-install-recommends install curl openjdk-8-jre-headless && \
-    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local/share/minimesos
 

--- a/bin/minimesos
+++ b/bin/minimesos
@@ -9,11 +9,6 @@ if ! command_exists docker; then
 	exit 1
 fi
 
-DOCKER_BIN=/usr/local/bin/docker
-if [ ! -f $DOCKER_BIN ]; then
-    DOCKER_BIN=/usr/bin/docker
-fi
-
 MINIMESOS_TAG="latest"
 MESOS_TAG="0.25.0-0.2.70.ubuntu1404"
 
@@ -27,4 +22,4 @@ pullImage "containersol/minimesos:${MINIMESOS_TAG}"
 pullImage "containersol/mesos-agent:${MESOS_TAG}"
 pullImage "containersol/mesos-master:${MESOS_TAG}"
 
-docker run -v $PWD:/tmp/minimesos -v /var/lib/docker:/var/lib/docker -v /var/run/docker.sock:/var/run/docker.sock -v $DOCKER_BIN:$DOCKER_BIN -v /sys/fs/cgroup:/sys/fs/cgroup containersol/minimesos:$MINIMESOS_TAG $@
+docker run --rm -v $PWD:/tmp/minimesos -v /var/run/docker.sock:/var/run/docker.sock containersol/minimesos:$MINIMESOS_TAG $@

--- a/src/main/java/com/containersol/minimesos/marathon/Marathon.java
+++ b/src/main/java/com/containersol/minimesos/marathon/Marathon.java
@@ -14,7 +14,7 @@ public class Marathon extends AbstractContainer {
     private static Logger LOGGER = Logger.getLogger(Marathon.class);
 
     private static final String MARATHON_IMAGE = "mesosphere/marathon";
-    public static final String REGISTRY_TAG = "v0.8.1";
+    public static final String REGISTRY_TAG = "v0.11.1";
 
     private String clusterId;
 

--- a/src/main/java/com/containersol/minimesos/mesos/MesosSlave.java
+++ b/src/main/java/com/containersol/minimesos/mesos/MesosSlave.java
@@ -1,14 +1,13 @@
 package com.containersol.minimesos.mesos;
 
+import com.containersol.minimesos.container.AbstractContainer;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Link;
 import org.apache.log4j.Logger;
-import com.containersol.minimesos.container.AbstractContainer;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
@@ -48,7 +47,7 @@ public class MesosSlave extends AbstractContainer {
     }
 
     String[] createMesosLocalEnvironment() {
-        TreeMap<String,String> envs = new TreeMap<>();
+        TreeMap<String, String> envs = new TreeMap<>();
 
         envs.put("MESOS_PORT", this.portNumber);
         envs.put("MESOS_MASTER", this.zkUrl);
@@ -65,17 +64,6 @@ public class MesosSlave extends AbstractContainer {
     }
 
     public CreateContainerCmd getBaseCommand() {
-
-        String dockerBin = "/usr/bin/docker";
-        File dockerBinFile = new File(dockerBin);
-        if (!(dockerBinFile.exists() && dockerBinFile.canExecute())) {
-            dockerBin = "/usr/local/bin/docker";
-            dockerBinFile = new File(dockerBin);
-            if (!(dockerBinFile.exists() && dockerBinFile.canExecute() )) {
-                LOGGER.error("Docker binary not found in /usr/local/bin or /usr/bin. Creating containers will most likely fail.");
-            }
-        }
-
         return dockerClient.createContainerCmd(mesosLocalImage + ":" + registryTag)
                 .withName("minimesos-agent-" + clusterId + "-" + getRandomId())
                 .withPrivileged(true)
@@ -83,9 +71,7 @@ public class MesosSlave extends AbstractContainer {
                 .withPid("host")
                 .withLinks(new Link(this.master, "minimesos-master"))
                 .withBinds(
-                        Bind.parse("/var/lib/docker:/var/lib/docker"),
                         Bind.parse("/sys/fs/cgroup:/sys/fs/cgroup"),
-                        Bind.parse(String.format("%s:/usr/bin/docker", dockerBin)),
                         Bind.parse("/var/run/docker.sock:/var/run/docker.sock")
                 );
     }
@@ -97,7 +83,7 @@ public class MesosSlave extends AbstractContainer {
 
     @Override
     protected CreateContainerCmd dockerCommand() {
-        ArrayList<ExposedPort> exposedPorts= new ArrayList<>();
+        ArrayList<ExposedPort> exposedPorts = new ArrayList<>();
         exposedPorts.add(new ExposedPort(Integer.parseInt(this.portNumber)));
         try {
             ArrayList<Integer> resourcePorts = this.parsePortsFromResource(this.resources);


### PR DESCRIPTION
Couple of changes:

- The Dockerfile now has a parent with jre8 and the docker client in it, so builds should be faster
- The minimesos container is removed after it's done, fixes https://github.com/ContainerSolutions/minimesos/issues/124
- Upgraded Marathon (from v0.8.0 to v0.11.1)
- Because the docker client is now included in the (parent) image, it's no longer necessary to `-v` it in, we just need the `docker.sock` and `/sys` on the `mesos-agent`

