### PR TITLE
Checking cluster state and removing invalid state file

### DIFF
--- a/src/main/java/com/containersol/minimesos/main/Main.java
+++ b/src/main/java/com/containersol/minimesos/main/Main.java
@@ -33,8 +33,11 @@ public class Main {
         jc.addCommand("help", commandHelp);
         jc.parseWithoutValidation(args);
 
+        String clusterId = MesosCluster.readClusterId();
+        MesosCluster.checkStateFile(clusterId);
+        clusterId = MesosCluster.readClusterId();
+
         if (jc.getParsedCommand() == null) {
-            String clusterId = MesosCluster.readClusterId();
             if (clusterId != null) {
                 MesosCluster.printMasterIp(clusterId);
             } else {


### PR DESCRIPTION
Fixes #104 

If there's a state file, but the corresponding cluster is not available (e.g. the virtual machine was destroyed meanwhile), state file is removed and user is notified.