### PR TITLE
Fixes to bin/minimesos

### DIFF
--- a/bin/minimesos
+++ b/bin/minimesos
@@ -10,12 +10,12 @@ if ! command_exists docker; then
 fi
 
 DOCKER_BIN=/usr/local/bin/docker
-if [ ! -f $DOCKER_BIN ]; then
+if [ ! -f "${DOCKER_BIN}" ]; then
     DOCKER_BIN=/usr/bin/docker
 fi
 
 docker info > /dev/null 2>&1
-if [ $? != 0 ]; then
+if [ "$?" -ne 0 ]; then
     echo "Please make sure docker is set up correctly"
     exit 1
 fi
@@ -30,13 +30,26 @@ pullImage() {
   fi
 }
 
-if [ $@ = "up" ]; then
-    pullImage "containersol/minimesos" ${MINIMESOS_TAG}
-    pullImage "containersol/mesos-agent" ${MESOS_TAG}
-    pullImage "containersol/mesos-master" ${MESOS_TAG}
+if [ "$#" -gt 0 -a "$1" = up ]; then
+    echo "Pulling images required to launch minimesos ..."
+    pullImage "containersol/minimesos" "${MINIMESOS_TAG}"
+    pullImage "containersol/mesos-agent" "${MESOS_TAG}"
+    pullImage "containersol/mesos-master" "${MESOS_TAG}"
+    echo "Finished pulling images."
 fi
 
-MINIMESOS_DIR=$(pwd)/.minimesos
-mkdir -p $MINIMESOS_DIR
+MINIMESOS_DIR="$(pwd)/.minimesos"
+if [ ! -d ${MINIMESOS_DIR} ]; then
+    mkdir -p ${MINIMESOS_DIR}
+    echo "Created minimesos directory at ${MINIMESOS_DIR}."
+fi
 
-docker run --rm -v $MINIMESOS_DIR:/tmp/.minimesos -v /var/lib/docker:/var/lib/docker -v /var/run/docker.sock:/var/run/docker.sock -v $DOCKER_BIN:$DOCKER_BIN -v /sys/fs/cgroup:/sys/fs/cgroup --rm containersol/minimesos:$MINIMESOS_TAG $@
+docker run \
+       --rm \
+       -v "${MINIMESOS_DIR}:/tmp/.minimesos" \
+       -v "/var/lib/docker:/var/lib/docker" \
+       -v "/var/run/docker.sock:/var/run/docker.sock" \
+       -v "${DOCKER_BIN}:${DOCKER_BIN}" \
+       -v "/sys/fs/cgroup:/sys/fs/cgroup" \
+       "containersol/minimesos:${MINIMESOS_TAG}" \
+       $@


### PR DESCRIPTION
* Test that first argument to script, if passed, is "up", not that it is the exact sole argument. Subsequent arguments can be passed to the script.
* Surround variable references with quotes where they are intended to evaluate to a single token.
* Replace string equality test "!=" with numeric equality test "-ne" when testing for numeric equality.
* Consistent use of ${...} variable references.
* Split very long command over multiple lines.
* Remove duplicated argument "--rm" to "docker run".
* Notify user of script actions, such as creating the minimesos directory and pulling Docker images.