### PR TITLE
Enable setting of Marathon and ZooKeeper image tags from command-line

### DIFF
--- a/minimesos/src/main/java/com/containersol/minimesos/main/CommandUp.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/main/CommandUp.java
@@ -2,7 +2,9 @@ package com.containersol.minimesos.main;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.containersol.minimesos.marathon.Marathon;
 import com.containersol.minimesos.mesos.MesosContainer;
+import com.containersol.minimesos.mesos.ZooKeeper;
 
 /**
  * Parameters for the 'up' command
@@ -10,14 +12,28 @@ import com.containersol.minimesos.mesos.MesosContainer;
 @Parameters(separators = "=", commandDescription = "Create a minimesos cluster")
 public class CommandUp {
 
-    @Parameter(names = "--mesosImageTag", description = "The tag of the Mesos master and agent Docker images.")
-    private String mesosImageTag = MesosContainer.MESOS_IMAGE_TAG;
-
     @Parameter(names = "--exposedHostPorts", description = "Expose the Mesos and Marathon UI ports on the host level (we recommend to enable this on Mac (e.g. when using docker-machine) and disable on Linux).")
     private boolean exposedHostPorts = false;
 
+    @Parameter(names = "--marathonImageTag", description = "The tag of the Marathon Docker image.")
+    private String marathonImageTag = Marathon.MARATHON_IMAGE_TAG;
+
+    @Parameter(names = "--mesosImageTag", description = "The tag of the Mesos master and agent Docker images.")
+    private String mesosImageTag = MesosContainer.MESOS_IMAGE_TAG;
+
+    @Parameter(names = "--zooKeeperImageTag", description = "The tag of the ZooKeeper Docker images.")
+    private String zooKeeperImageTag = ZooKeeper.ZOOKEEPER_IMAGE_TAG;
+
+    public String getMarathonImageTag() {
+        return marathonImageTag;
+    }
+
     public String getMesosImageTag() {
         return mesosImageTag;
+    }
+
+    public String getZooKeeperImageTag() {
+        return zooKeeperImageTag;
     }
 
     public boolean isExposedHostPorts() {

--- a/minimesos/src/main/java/com/containersol/minimesos/main/Main.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/main/Main.java
@@ -67,17 +67,19 @@ public class Main {
         String clusterId = MesosCluster.readClusterId();
 
         boolean exposedHostPorts = commandUp.isExposedHostPorts();
+        String marathonImageTag = commandUp.getMarathonImageTag();
         String mesosImageTag = commandUp.getMesosImageTag();
+        String zooKeeperImageTag = commandUp.getZooKeeperImageTag();
 
         if (clusterId == null) {
 
             DockerClient dockerClient = DockerClientFactory.build();
 
             ClusterArchitecture config = new ClusterArchitecture.Builder(dockerClient)
-                    .withZooKeeper()
+                    .withZooKeeper(zooKeeperImageTag)
                     .withMaster(zooKeeper -> new MesosMasterExtended( dockerClient, zooKeeper, MesosMaster.MESOS_MASTER_IMAGE, mesosImageTag, new TreeMap<>(), exposedHostPorts))
                     .withSlave(zooKeeper -> new MesosSlaveExtended( dockerClient, "ports(*):[33000-34000]", "5051", zooKeeper, MesosSlave.MESOS_SLAVE_IMAGE, mesosImageTag))
-                    .withContainer( zooKeeper -> new Marathon(dockerClient, zooKeeper, exposedHostPorts), ClusterContainers.Filter.zooKeeper() )
+                    .withContainer( zooKeeper -> new Marathon(dockerClient, zooKeeper, marathonImageTag, exposedHostPorts), ClusterContainers.Filter.zooKeeper() )
                     .build();
 
             MesosCluster cluster = new MesosCluster( config );

--- a/minimesos/src/main/java/com/containersol/minimesos/marathon/Marathon.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/marathon/Marathon.java
@@ -14,22 +14,23 @@ import org.apache.log4j.Logger;
 public class Marathon extends AbstractContainer {
 
     private static final String MARATHON_IMAGE = "mesosphere/marathon";
-    public static final String REGISTRY_TAG = "v0.11.1";
+    public static final String MARATHON_IMAGE_TAG = "v0.11.1";
     public static final int MARATHON_PORT = 8080;
 
     private ZooKeeper zooKeeper;
-
+    private String marathonImageTag = MARATHON_IMAGE_TAG;
     private Boolean exposedHostPort;
 
-    public Marathon(DockerClient dockerClient, ZooKeeper zooKeeper, Boolean exposedHostPort) {
+    public Marathon(DockerClient dockerClient, ZooKeeper zooKeeper, String marathonImageTag, Boolean exposedHostPort) {
         super(dockerClient);
         this.zooKeeper = zooKeeper;
+        this.marathonImageTag = marathonImageTag;
         this.exposedHostPort = exposedHostPort;
     }
 
     @Override
     protected void pullImage() {
-        pullImage(MARATHON_IMAGE, REGISTRY_TAG);
+        pullImage(MARATHON_IMAGE, marathonImageTag);
     }
 
     @Override
@@ -39,7 +40,7 @@ public class Marathon extends AbstractContainer {
         if (exposedHostPort) {
             portBindings.bind(exposedPort, Ports.Binding(MARATHON_PORT));
         }
-        return dockerClient.createContainerCmd(MARATHON_IMAGE + ":" + REGISTRY_TAG)
+        return dockerClient.createContainerCmd(MARATHON_IMAGE + ":" + marathonImageTag)
                 .withName("minimesos-marathon-" + getClusterId() + "-" + getRandomId())
                 .withExtraHosts("minimesos-zookeeper:" + this.zooKeeper.getIpAddress())
                 .withCmd("--master", "zk://minimesos-zookeeper:2181/mesos", "--zk", "zk://minimesos-zookeeper:2181/marathon")
@@ -47,4 +48,11 @@ public class Marathon extends AbstractContainer {
                 .withPortBindings(portBindings);
     }
 
+    public String getMarathonImageTag() {
+        return marathonImageTag;
+    }
+
+    public void setMarathonImageTag(String marathonImageTag) {
+        this.marathonImageTag = marathonImageTag;
+    }
 }

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/ClusterArchitecture.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/ClusterArchitecture.java
@@ -110,7 +110,14 @@ public class ClusterArchitecture {
          * Includes the default {@link ZooKeeper} instance in the cluster
          */
         public Builder withZooKeeper() {
-            return withZooKeeper(new ZooKeeper(dockerClient));
+            return withZooKeeper(ZooKeeper.ZOOKEEPER_IMAGE_TAG);
+        }
+
+        /**
+         * Be explicit about the version of the image to use.
+         */
+        public Builder withZooKeeper(String zooKeeperImageTag) {
+            return withZooKeeper(new ZooKeeper(dockerClient, zooKeeperImageTag));
         }
 
         /**

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/ZooKeeper.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/ZooKeeper.java
@@ -11,23 +11,34 @@ import com.github.dockerjava.api.model.ExposedPort;
  */
 public class ZooKeeper extends AbstractContainer {
     public static final String MESOS_LOCAL_IMAGE = "jplock/zookeeper";
-    public static final String REGISTRY_TAG = "3.4.6";
+    public static final String ZOOKEEPER_IMAGE_TAG = "3.4.6";
     public static final int DEFAULT_ZOOKEEPER_PORT = 2181;
 
-    protected ZooKeeper(DockerClient dockerClient) {
+    private String zooKeeperImageTag = ZOOKEEPER_IMAGE_TAG;
+
+    protected ZooKeeper(DockerClient dockerClient, String zooKeeperImageTag) {
         super(dockerClient);
+        this.zooKeeperImageTag = zooKeeperImageTag;
     }
 
     @Override
     protected void pullImage() {
-        pullImage(MESOS_LOCAL_IMAGE, REGISTRY_TAG);
+        pullImage(MESOS_LOCAL_IMAGE, zooKeeperImageTag);
     }
 
     @Override
     protected CreateContainerCmd dockerCommand() {
-        return dockerClient.createContainerCmd(MESOS_LOCAL_IMAGE + ":" + REGISTRY_TAG)
+        return dockerClient.createContainerCmd(MESOS_LOCAL_IMAGE + ":" + zooKeeperImageTag)
                 .withName("minimesos-zookeeper-" + MesosCluster.getClusterId() + "-" + getRandomId())
                 .withExposedPorts(new ExposedPort(DEFAULT_ZOOKEEPER_PORT), new ExposedPort(2888), new ExposedPort(3888));
+    }
+
+    public String getZooKeeperImageTag() {
+        return zooKeeperImageTag;
+    }
+
+    public void setZooKeeperImageTag(String zooKeeperImageTag) {
+        this.zooKeeperImageTag = zooKeeperImageTag;
     }
 
     public static String formatZKAddress(String ipAddress) {


### PR DESCRIPTION
This patch enables you to do this:
`minimesos up --marathonImageTag=v0.13.0 --zooKeeperImageTag=3.4.2`

NOTE: if you run `./gradlew test` then you'll notice 2 tests fail, but these also currently fail on `master` (ie I didn't break anything extra).