### PR TITLE
Test-framework-docker executor/scheduler startup scripts are made exe…

### DIFF
--- a/test-framework-docker/executor/Dockerfile
+++ b/test-framework-docker/executor/Dockerfile
@@ -12,4 +12,6 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
 ADD ./build/docker/mesos-hello-world-executor.jar /tmp/mesos-hello-world-executor.jar
 ADD ./build/docker/start-executor.sh /tmp/start-executor.sh
 
+RUN chmod +x /tmp/start-executor.sh
+
 ENTRYPOINT ["/tmp/start-executor.sh"]

--- a/test-framework-docker/scheduler/Dockerfile
+++ b/test-framework-docker/scheduler/Dockerfile
@@ -12,4 +12,6 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
 ADD ./build/docker/mesos-hello-world-scheduler.jar /tmp/mesos-hello-world-scheduler.jar
 ADD ./build/docker/start-scheduler.sh /tmp/start-scheduler.sh
 
+RUN chmod +x /tmp/start-scheduler.sh
+
 ENTRYPOINT ["/tmp/start-scheduler.sh"]


### PR DESCRIPTION
Test-framework-docker executor/scheduler startup scripts are not explicitly set to be executable which might cause an error when you copy the sh scripts to another place and want to reuse the test-framework-docker