### PR TITLE
Refactoring/skimming docker images

### DIFF
--- a/bin/minimesos
+++ b/bin/minimesos
@@ -1,17 +1,17 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 MINIMESOS_TAG="latest"
 MESOS_TAG="0.25.0-0.2.70.ubuntu1404.b1"
-
+DOCKER_BIN="$(command -v docker)"
 PARAMS="$@"
 
 command_exists() {
-	command -v "$@" > /dev/null 2>&1
+    command -v "$@" > /dev/null 2>&1
 }
 
 if ! command_exists docker; then
-	echo "Please install docker to use minimesos"
-	exit 1
+    echo "Please install docker to use minimesos"
+    exit 1
 fi
 
 if command_exists docker-machine && [ "$DOCKER_MACHINE_NAME" != "" ]; then
@@ -22,10 +22,10 @@ else
     DOCKER_HOST_IP=""
 fi
 
-DOCKER_BIN=/usr/local/bin/docker
-if [ ! -f "${DOCKER_BIN}" ]; then
-    DOCKER_BIN=/usr/bin/docker
-fi
+# DOCKER_BIN=/usr/local/bin/docker
+# if [ ! -f "${DOCKER_BIN}" ]; then
+#     DOCKER_BIN=/usr/bin/docker
+# fi
 
 docker info > /dev/null 2>&1
 if [ "$?" -ne 0 ]; then
@@ -34,10 +34,10 @@ if [ "$?" -ne 0 ]; then
 fi
 
 pullImage() {
-  if [ "$(docker images $1 | grep $2 2> /dev/null)" = "" ]; then
-    echo "Pulling $1:$2"
-    docker pull "$1:$2"
-  fi
+    if [ "$(docker images $1 | grep $2 2> /dev/null)" = "" ]; then
+	echo "Pulling $1:$2"
+	docker pull "$1:$2"
+    fi
 }
 
 if [ "$#" -gt 0 -a "$1" = up ]; then
@@ -47,8 +47,8 @@ if [ "$#" -gt 0 -a "$1" = up ]; then
     pullImage "containersol/mesos-master" ${MESOS_TAG}
     echo "Finished pulling images."
     if [ "$(uname)" = "Darwin" ]; then
-        echo "You are running minimesos on OS X, enabling --exposedHostPorts"
-        PARAMS="${PARAMS} --exposedHostPorts"
+	echo "You are running minimesos on OS X, enabling --exposedHostPorts"
+	PARAMS="${PARAMS} --exposedHostPorts"
     fi
 fi
 
@@ -64,6 +64,7 @@ docker run \
        -v "${MINIMESOS_HOST_DIR}:${MINIMESOS_HOST_DIR}" \
        -v "/var/run/docker.sock:/var/run/docker.sock" \
        -v "/sys/fs/cgroup:/sys/fs/cgroup" \
+       -v "${DOCKER_BIN}:/usr/bin/docker" \
        -i \
        --env DOCKER_HOST_IP=$DOCKER_HOST_IP \
        --entrypoint java \

--- a/bin/minimesos
+++ b/bin/minimesos
@@ -22,10 +22,6 @@ else
     DOCKER_HOST_IP=""
 fi
 
-# DOCKER_BIN=/usr/local/bin/docker
-# if [ ! -f "${DOCKER_BIN}" ]; then
-#     DOCKER_BIN=/usr/bin/docker
-# fi
 
 docker info > /dev/null 2>&1
 if [ "$?" -ne 0 ]; then

--- a/minimesos/Dockerfile
+++ b/minimesos/Dockerfile
@@ -1,33 +1,13 @@
-FROM ubuntu:14.04
+FROM alpine:latest
 MAINTAINER Container Solutions BV <info@container-solutions.com>
 
 # Let's start with some basic stuff.
-RUN apt-get update -qq && apt-get install -qqy \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    lxc \
-    iptables
-
-RUN echo "deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty main" > /etc/apt/sources.list.d/openjdk.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv 86F44E2A && \
-    apt-get update && \
-    apt-get -y --no-install-recommends install curl openjdk-8-jre-headless && \
-    rm -rf /var/lib/apt/lists/*
-
-ENV DOCKER_VERSION=1.9.1
-ENV DOCKER_SHA1=424920b09c24d7c7876cc35d8aabd2aa52b8e39e
-# ENV DOCKER_VERSION=1.7.1
-# ENV DOCKER_SHA1=386f6e91114dc252a13b266fe2ac3a27e83bd0f7
-# ENV DOCKER_VERSION=1.8.3
-# ENV DOCKER_SHA1=401971958a095fe2f9c42a35effb1b0245e52e87
-RUN curl -s --continue-at - -SL "https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}" > /usr/bin/docker && \
-    chmod a+x /usr/bin/docker && \
-    echo "${DOCKER_SHA1}  /usr/bin/docker" | sha1sum -c -
+RUN apk --update add openjdk8-jre
 
 RUN mkdir -p /usr/local/share/minimesos
-
 ADD minimesos.jar /usr/local/share/minimesos/minimesos.jar
+
+VOLUME ["/usr/bin/docker"]
 
 ENTRYPOINT ["java",  "-Dminimesos.dir=/tmp/.minimesos", "-jar", "/usr/local/share/minimesos/minimesos.jar"]
 

--- a/minimesos/Dockerfile
+++ b/minimesos/Dockerfile
@@ -1,9 +1,7 @@
 FROM alpine:latest
 MAINTAINER Container Solutions BV <info@container-solutions.com>
 
-# Let's start with some basic stuff.
 RUN apk --update add openjdk8-jre
-
 RUN mkdir -p /usr/local/share/minimesos
 ADD minimesos.jar /usr/local/share/minimesos/minimesos.jar
 

--- a/minimesos/src/main/resources/marathon/mesos-consul.json
+++ b/minimesos/src/main/resources/marathon/mesos-consul.json
@@ -8,7 +8,7 @@
     "type": "DOCKER",
     "docker": {
       "network": "BRIDGE",
-      "image": "ciscocloud/mesos-consul:latest"
+      "image": "containersol/mesos-consul:latest"
     }
   },
   "id": "mesos-consul",

--- a/minimesos/src/test/java/com/containersol/minimesos/MesosClusterTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/MesosClusterTest.java
@@ -48,7 +48,7 @@ public class MesosClusterTest {
     @After
     public void after() {
         DockerContainersUtil util = new DockerContainersUtil(CONFIG.dockerClient);
-        util.getContainers(true).filterByName("^mesos-[0-9a-f\\-]*S\\d*\\.[0-9a-f\\-]*$").remove();
+        util.getContainers(false).filterByName("^mesos-[0-9a-f\\-]*S\\d*\\.[0-9a-f\\-]*$").remove();
     }
 
     @Test

--- a/minimesos/src/test/java/com/containersol/minimesos/NewMesosClusterTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/NewMesosClusterTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Replicates MesosClusterTest with new API
  */
+
 public class NewMesosClusterTest {
 
     private DockerClient dockerClient = DockerClientFactory.build();
@@ -41,7 +42,7 @@ public class NewMesosClusterTest {
     @After
     public void after() {
         DockerContainersUtil util = new DockerContainersUtil(dockerClient);
-        util.getContainers(true).filterByName("^mesos-[0-9a-f\\-]*S\\d*\\.[0-9a-f\\-]*$").remove();
+        util.getContainers(false).filterByName("^mesos-[0-9a-f\\-]*S\\d*\\.[0-9a-f\\-]*$").remove();
     }
 
     @Test


### PR DESCRIPTION
- clean-ups in bin/minimesos
- use alpine instead of ubuntu image for minimesos container
- remove built-in docker binary, use volume instead
- only remove running containers when cleaning up tests, to avoid long-runnning process of removing all containers, not the only ones that are running