### PR TITLE
feature: Environment variables for all AbstractContainers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ deps:
 
 clean:
 	./gradlew clean
-	docker rmi containersol/minimesos:latest
-	docker rmi containersol/mesos-hello-world-scheduler:latest
-	docker rmi containersol/mesos-hello-world-executor:latest
+	-docker rmi containersol/minimesos:latest
+	-docker rmi containersol/mesos-hello-world-scheduler:latest
+	-docker rmi containersol/mesos-hello-world-executor:latest
 
 build:
 	./gradlew build --info --stacktrace

--- a/minimesos/src/main/java/com/containersol/minimesos/container/AbstractContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/container/AbstractContainer.java
@@ -18,6 +18,8 @@ import org.apache.log4j.Logger;
 
 import java.security.SecureRandom;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.*;
 
 import static com.jayway.awaitility.Awaitility.await;
@@ -37,6 +39,8 @@ public abstract class AbstractContainer {
     private boolean removed;
 
     protected DockerClient dockerClient;
+
+    protected Map<String, String> envVars = new TreeMap<>();
 
     protected AbstractContainer(DockerClient dockerClient) {
         this.dockerClient = dockerClient;
@@ -226,6 +230,10 @@ public abstract class AbstractContainer {
      */
     public String getClusterId() {
         return (cluster != null) ? cluster.getClusterId() : null;
+    }
+
+    protected String[] createEnvironment() {
+        return envVars.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).toArray(String[]::new);
     }
 
     private class ContainerIsRunning implements Callable<Boolean> {

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/Consul.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/Consul.java
@@ -46,9 +46,12 @@ public class Consul extends AbstractContainer {
         String gatewayIpAddress = DockerContainersUtil.getGatewayIpAddress(dockerClient);
         portBindings.bind(consulDNSPort, Ports.Binding(gatewayIpAddress, DNS_PORT));
 
+        envVars.put("SERVICE_IGNORE", "1");
+
         return dockerClient.createContainerCmd(config.getImageName() + ":" + config.getImageTag())
                 .withName(getName())
                 .withPortBindings(portBindings)
+                .withEnv(createEnvironment())
                 .withExposedPorts(consulHTTPPort, consulDNSPort);
     }
 

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosAgent.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosAgent.java
@@ -12,6 +12,7 @@ import com.github.dockerjava.api.model.Link;
 import org.apache.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.TreeMap;
 
 /**
@@ -91,8 +92,8 @@ public class MesosAgent extends MesosContainer {
     }
 
     @Override
-    public TreeMap<String, String> getDefaultEnvVars() {
-        TreeMap<String,String> envs = new TreeMap<>();
+    public Map<String, String> getDefaultEnvVars() {
+        Map<String,String> envs = new TreeMap<>();
         envs.put("MESOS_RESOURCES", getResources());
         envs.put("MESOS_PORT", String.valueOf(getPortNumber()));
         envs.put("MESOS_MASTER", getFormattedZKAddress());

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosContainer.java
@@ -11,6 +11,7 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.GetRequest;
 import org.json.JSONObject;
 
+import java.util.Map;
 import java.util.TreeMap;
 
 /**
@@ -37,7 +38,7 @@ public abstract class MesosContainer extends AbstractContainer {
 
     public abstract int getPortNumber();
 
-    protected abstract TreeMap<String, String> getDefaultEnvVars();
+    protected abstract Map<String, String> getDefaultEnvVars();
 
     @Override
     protected void pullImage() {
@@ -58,13 +59,13 @@ public abstract class MesosContainer extends AbstractContainer {
     }
 
     protected String[] createMesosLocalEnvironment() {
-        TreeMap<String, String> map = getDefaultEnvVars();
-        map.putAll(getSharedEnvVars());
-        return map.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).toArray(String[]::new);
+        envVars.putAll(getDefaultEnvVars());
+        envVars.putAll(getSharedEnvVars());
+        return createEnvironment();
     }
 
-    protected TreeMap<String, String> getSharedEnvVars() {
-        TreeMap<String,String> envs = new TreeMap<>();
+    protected Map<String, String> getSharedEnvVars() {
+        Map<String, String> envs = new TreeMap<>();
         envs.put("GLOG_v", "1");
         envs.put("MESOS_EXECUTOR_REGISTRATION_TIMEOUT", "5mins");
         envs.put("MESOS_CONTAINERIZERS", "docker,mesos");

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosMaster.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosMaster.java
@@ -50,8 +50,8 @@ public class MesosMaster extends MesosContainer {
     }
 
     @Override
-    public TreeMap<String, String> getDefaultEnvVars() {
-        TreeMap<String, String> envs = new TreeMap<>();
+    public Map<String, String> getDefaultEnvVars() {
+        Map<String, String> envs = new TreeMap<>();
         envs.put("MESOS_QUORUM", "1");
         envs.put("MESOS_ZK", getFormattedZKAddress());
         envs.put("MESOS_LOGGING_LEVEL", getLoggingLevel());

--- a/minimesos/src/test/java/com/containersol/minimesos/ConsulRegistrationTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/ConsulRegistrationTest.java
@@ -16,6 +16,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class ConsulRegistrationTest {
 
@@ -50,6 +51,23 @@ public class ConsulRegistrationTest {
 
         JSONObject service = body.getJSONObject(0);
         assertEquals(HelloWorldContainer.SERVICE_PORT, service.getInt("ServicePort"));
+    }
+
+    @Test
+    public void testConsulShouldBeIgnored() throws UnirestException {
+        String ipAddress = DockerContainersUtil.getIpAddress(dockerClient, CLUSTER.getConsulContainer().getContainerId());
+        String url = String.format("http://%s:%d/v1/catalog/services", ipAddress, ConsulConfig.CONSUL_HTTP_PORT);
+
+        JSONArray body = Unirest.get(url).asJson().getBody().getArray();
+        assertEquals(1, body.length());
+
+        JSONObject service = body.getJSONObject(0);
+        assertFalse(service.has("consul-server-8300"));
+        assertFalse(service.has("consul-server-8301"));
+        assertFalse(service.has("consul-server-8302"));
+        assertFalse(service.has("consul-server-8400"));
+        assertFalse(service.has("consul-server-8500"));
+        assertFalse(service.has("consul-server-8600"));
     }
 
 }

--- a/minimesos/src/test/java/com/containersol/minimesos/FlagsTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/FlagsTest.java
@@ -1,8 +1,8 @@
 package com.containersol.minimesos;
 
 import com.containersol.minimesos.cluster.MesosCluster;
-import com.containersol.minimesos.mesos.DockerClientFactory;
 import com.containersol.minimesos.mesos.ClusterArchitecture;
+import com.containersol.minimesos.mesos.DockerClientFactory;
 import com.containersol.minimesos.mesos.MesosMaster;
 import com.containersol.minimesos.mesos.ZooKeeper;
 import com.github.dockerjava.api.DockerClient;
@@ -10,8 +10,6 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import java.util.TreeMap;
 
 public class FlagsTest {
 
@@ -46,11 +44,11 @@ public class FlagsTest {
 
         @Override
         protected String[] createMesosLocalEnvironment() {
-            TreeMap<String, String> envs = getDefaultEnvVars();
-            envs.put("MESOS_AUTHENTICATE", "true");
-            envs.put("MESOS_ACLS", aclExampleJson);
+            envVars.putAll(getDefaultEnvVars());
+            envVars.put("MESOS_AUTHENTICATE", "true");
+            envVars.put("MESOS_ACLS", aclExampleJson);
 
-            return envs.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).toArray(String[]::new);
+            return createEnvironment();
         }
     }
 }


### PR DESCRIPTION
Pulled the bookkeeping and creation of env vars up to AbstractContainer so all containers can set env vars.

Also ignored the Consul service from being registered in Consul.

Any container that inherits from `AbstractContainer` can now add to the `protected envVars Map`. Then call `.withEnv(createEnvironment())` and you are good.