### PR TITLE
writing cluster ID before attempting to start it

### DIFF
--- a/minimesos/src/main/java/com/containersol/minimesos/main/CommandUp.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/main/CommandUp.java
@@ -145,12 +145,14 @@ public class CommandUp implements Command {
         ClusterArchitecture clusterArchitecture = getClusterArchitecture();
 
         startedCluster = new MesosCluster(clusterArchitecture);
+        // save cluster ID first, so it becomes available for 'destroy' even if its part failed to start
+        ClusterRepository.saveClusterFile(startedCluster);
+
         startedCluster.start();
         startedCluster.waitForState(state -> state != null);
 
         startedCluster.printServiceUrls(output);
 
-        ClusterRepository.saveClusterFile(startedCluster);
     }
 
    /**


### PR DESCRIPTION
With this change it becomes possible to `destroy` cluster even when its part failed to start

```
vikmac:mini-mesos vik$ ./bin/minimesos up || echo "FAILED NICELY ;-)"
# You are running minimesos on OS X, enabling --exposedHostPorts
Failed to load JSON from https://raw.githubusercontent.com/ContainerSolutions/minimesos/27744df7071fb2d4ab15ec37f4d539d/apps/weave-scope.json
FAILED NICELY ;-)

vikmac:mini-mesos vik$ docker ps -a
CONTAINER ID        IMAGE                                                COMMAND                  CREATED             STATUS              PORTS                                                                                               NAMES
dadd04baccd4        gliderlabs/registrator:v6                            "/bin/registrator -in"   14 seconds ago      Up 14 seconds                                                                                                           minimesos-registrator-2934477846-4040310141
5bd8d66ac411        containersol/consul-server:0.6                       "/bin/consul agent -s"   16 seconds ago      Up 16 seconds       8300-8302/tcp, 8400/tcp, 8600/tcp, 8301-8302/udp, 0.0.0.0:8500->8500/tcp, 172.17.0.1:53->8600/udp   minimesos-consul-2934477846-93663016
4a26b10e190b        containersol/mesos-agent:0.25.0-0.2.70.ubuntu1404    "mesos-slave --no-hos"   18 seconds ago      Up 18 seconds       5051/tcp, 31000-32000/tcp                                                                           minimesos-agent-2934477846-4109090408
9d4c495387f8        containersol/mesos-agent:0.25.0-0.2.70.ubuntu1404    "mesos-slave --no-hos"   20 seconds ago      Up 19 seconds       5051/tcp, 31000-32000/tcp                                                                           minimesos-agent-2934477846-3882282258
3e2bd2fbdf91        mesosphere/marathon:v0.15.3                          "./bin/start --master"   21 seconds ago      Up 21 seconds       0.0.0.0:8080->8080/tcp                                                                              minimesos-marathon-2934477846-3993107143
479c393a04f6        containersol/mesos-master:0.25.0-0.2.70.ubuntu1404   "mesos-master --regis"   22 seconds ago      Up 22 seconds       0.0.0.0:5050->5050/tcp                                                                              minimesos-master-2934477846-817401575
59f7100ac9cf        jplock/zookeeper:3.4.6                               "/opt/zookeeper/bin/z"   24 seconds ago      Up 24 seconds       2181/tcp, 2888/tcp, 3888/tcp                                                                        minimesos-zookeeper-2934477846-1623877548

vikmac:mini-mesos vik$ ./bin/minimesos destroy
Destroyed minimesos cluster with ID 2934477846

vikmac:mini-mesos vik$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES

vikmac:mini-mesos vik$
```