### PR TITLE
#227 - don't store environment map

### DIFF
--- a/minimesos/src/main/java/com/containersol/minimesos/container/AbstractContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/container/AbstractContainer.java
@@ -16,8 +16,6 @@ import org.slf4j.LoggerFactory;
 
 import java.security.SecureRandom;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Awaitility.await;
@@ -37,8 +35,6 @@ public abstract class AbstractContainer implements ClusterProcess {
     private String containerId;
     private String ipAddress = null;
     private boolean removed;
-
-    protected Map<String, String> envVars = new TreeMap<>();
 
     protected AbstractContainer(ContainerConfig config) {
         this.config = config;
@@ -217,11 +213,6 @@ public abstract class AbstractContainer implements ClusterProcess {
     public String getClusterId() {
         return (cluster != null) ? cluster.getClusterId() : null;
     }
-
-    protected String[] createEnvironment() {
-        return envVars.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).toArray(String[]::new);
-    }
-
 
     @Override
     public String toString() {

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/ConsulContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/ConsulContainer.java
@@ -10,6 +10,8 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Ports;
 
+import static com.containersol.minimesos.util.EnvironmentBuilder.newEnvironment;
+
 /**
  * This is the Consul-in-a-container container. Consul adds service discovery through DNS, and a distributed k/v store.
  */
@@ -51,12 +53,12 @@ public class ConsulContainer extends AbstractContainer implements Consul {
         String gatewayIpAddress = DockerContainersUtil.getGatewayIpAddress();
         portBindings.bind(consulDNSPort, new Ports.Binding(gatewayIpAddress, DNS_PORT));
 
-        envVars.put("SERVICE_IGNORE", "1");
-
         return DockerClientFactory.build().createContainerCmd(config.getImageName() + ":" + config.getImageTag())
                 .withName(getName())
                 .withPortBindings(portBindings)
-                .withEnv(createEnvironment())
+                .withEnv(newEnvironment()
+                        .withValue("SERVICE_IGNORE", "1")
+                        .createEnvironment())
                 .withExposedPorts(consulHTTPPort, consulDNSPort);
     }
 

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosAgentContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosAgentContainer.java
@@ -16,6 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static com.containersol.minimesos.util.EnvironmentBuilder.newEnvironment;
+
 /**
  * Mesos Master adds the "agent" component for Apache Mesos
  */
@@ -69,7 +71,10 @@ public class MesosAgentContainer extends MesosContainerImpl implements MesosAgen
         return DockerClientFactory.build().createContainerCmd(getImageName() + ":" + getImageTag())
                 .withName(getName())
                 .withPrivileged(true)
-                .withEnv(createMesosLocalEnvironment())
+                .withEnv(newEnvironment()
+                        .withValues(getMesosAgentEnvVars())
+                        .withValues(getSharedEnvVars())
+                        .createEnvironment())
                 .withPidMode("host")
                 .withLinks(new Link(getZooKeeper().getContainerId(), "minimesos-zookeeper"))
                 .withBinds(binds.stream().toArray(Bind[]::new));
@@ -95,8 +100,7 @@ public class MesosAgentContainer extends MesosContainerImpl implements MesosAgen
 
     }
 
-    @Override
-    public Map<String, String> getDefaultEnvVars() {
+    private Map<String, String> getMesosAgentEnvVars() {
         Map<String, String> envs = new TreeMap<>();
         envs.put("MESOS_RESOURCES", getResources());
         envs.put("MESOS_PORT", String.valueOf(getPortNumber()));

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosContainerImpl.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosContainerImpl.java
@@ -39,8 +39,6 @@ public abstract class MesosContainerImpl extends AbstractContainer implements Me
 
     public abstract int getPortNumber();
 
-    protected abstract Map<String, String> getDefaultEnvVars();
-
     @Override
     public String getImageTag() {
         String imageTag = config.getImageTag();
@@ -51,13 +49,7 @@ public abstract class MesosContainerImpl extends AbstractContainer implements Me
         return imageTag;
     }
 
-    protected String[] createMesosLocalEnvironment() {
-        envVars.putAll(getDefaultEnvVars());
-        envVars.putAll(getSharedEnvVars());
-        return createEnvironment();
-    }
-
-    protected Map<String, String> getSharedEnvVars() {
+    protected final Map<String, String> getSharedEnvVars() {
         Map<String, String> envs = new TreeMap<>();
         envs.put("GLOG_v", "1");
         envs.put("MESOS_EXECUTOR_REGISTRATION_TIMEOUT", "5mins");

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosMasterContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosMasterContainer.java
@@ -19,6 +19,7 @@ import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import static com.containersol.minimesos.util.EnvironmentBuilder.newEnvironment;
 import static com.jayway.awaitility.Awaitility.await;
 
 /**
@@ -47,8 +48,7 @@ public class MesosMasterContainer extends MesosContainerImpl implements MesosMas
         return MesosMasterConfig.MESOS_MASTER_PORT;
     }
 
-    @Override
-    public Map<String, String> getDefaultEnvVars() {
+    protected Map<String, String> getMesosMasterEnvVars() {
         Map<String, String> envs = new TreeMap<>();
         envs.put("MESOS_QUORUM", "1");
         if (((MesosMasterConfig) config).getAuthenticate() && ((MesosMasterConfig) config).getAclJson() != null) {
@@ -81,7 +81,10 @@ public class MesosMasterContainer extends MesosContainerImpl implements MesosMas
         return DockerClientFactory.build().createContainerCmd(getImageName() + ":" + getImageTag())
                 .withName(getName())
                 .withExposedPorts(new ExposedPort(getPortNumber()))
-                .withEnv(createMesosLocalEnvironment())
+                .withEnv(newEnvironment()
+                        .withValues(getMesosMasterEnvVars())
+                        .withValues(getSharedEnvVars())
+                        .createEnvironment())
                 .withPortBindings(portBindings);
     }
 

--- a/minimesos/src/main/java/com/containersol/minimesos/util/EnvironmentBuilder.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/util/EnvironmentBuilder.java
@@ -1,0 +1,31 @@
+package com.containersol.minimesos.util;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Provides convenient API for building a map of environment variables.
+ * Produces the String[] format needed by CreateContainerCmd.setEnv()
+ */
+public class EnvironmentBuilder {
+
+    private Map<String, String> envMap = new TreeMap<>();
+
+    public static EnvironmentBuilder newEnvironment() {
+        return new EnvironmentBuilder();
+    }
+
+    public EnvironmentBuilder withValue(String key, String value) {
+        envMap.put(key, value);
+        return this;
+    }
+
+    public EnvironmentBuilder withValues(Map<String, String> envMap) {
+        this.envMap.putAll(envMap);
+        return this;
+    }
+
+    public String[] createEnvironment() {
+        return envMap.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).toArray(String[]::new);
+    }
+}

--- a/minimesos/src/test/java/com/containersol/minimesos/util/EnvironmentBuilderTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/util/EnvironmentBuilderTest.java
@@ -1,0 +1,35 @@
+package com.containersol.minimesos.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.hamcrest.Matchers.array;
+import static org.hamcrest.Matchers.is;
+
+public class EnvironmentBuilderTest {
+
+    @Test
+    public void mergingSeveralSourcesProducesCorrectMap() {
+        Map<String, String> source1 = new TreeMap<>();
+        source1.put("envVar1", "value1");
+        source1.put("envVar2", "value2");
+        source1.put("envVar3", "value3");
+        source1.put("envVar4", "value4");
+        Map<String, String> source2 = new TreeMap<>();
+        source2.put("envVar5", "value5");
+        source2.put("envVar6", "value6");
+
+        String[] result = EnvironmentBuilder.newEnvironment()
+                .withValues(source1)
+                .withValue("envVarX", "valueX")
+                .withValues(source2)
+                .createEnvironment();
+
+        Assert.assertThat(result, array(is("envVar1=value1"),
+                is("envVar2=value2"), is("envVar3=value3"), is("envVar4=value4"),
+                is("envVar5=value5"), is("envVar6=value6"), is("envVarX=valueX")));
+    }
+}

--- a/travis.sh
+++ b/travis.sh
@@ -5,9 +5,15 @@ GH_SONARQ_PARAMS=""
 
 # When run on Travis CI, env var TRAVIS_PULL_REQUEST either contains PR number (for PR builds) or "false" (for push builds).
 # Locally this env var is not set. Test: if variable is not empty and is not equal "false"
-if [ ! -z "$TRAVIS_PULL_REQUEST" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+if [ ! -z "$TRAVIS_PULL_REQUEST" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
     echo "PR build. Will execute SonarQube preview scan"
     GH_SONARQ_PARAMS="jacocoTestReport sonarqube -Dsonar.analysis.mode=preview -Dsonar.host.url=$SQ_URL -Dsonar.github.oauth=$GH_TOKEN -Dsonar.github.repository=$TRAVIS_REPO_SLUG -Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST"
+fi
+
+# Update SonarQube data on push builds on master branch
+if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
+    echo "Building $TRAVIS_BRANCH branch. Will execute SonarQube scan"
+    GH_SONARQ_PARAMS="jacocoTestReport sonarqube -Dsonar.host.url=$SQ_URL -Dsonar.jdbc.url=$SQ_JDBC_URL -Dsonar.jdbc.driverClassName=org.postgresql.Driver -Dsonar.jdbc.user=$SQ_JDBC_USER -Dsonar.jdbc.password=$SQ_JDBC_PASSWORD"
 fi
 
 ./gradlew --info --stacktrace clean build $GH_SONARQ_PARAMS


### PR DESCRIPTION
Looking at the description of #227 I think the main problem is not a lack of setters (which can be added of course if needed) but the fact that the environment map is stored as a field in `AbstractContainer`. As it is only a map of constants and derived values storing it doesn't add value but can lead to problems if it becomes out of sync with the primary values. There is also a quite complex relation between `AbstractContainer` and its subclasses making it hard to track how the final map gets assembled. 

What I tried to do is:
1. Remove the `AbstractContainer.envVars` field + the conversion method that produces the String[]
2. Create the `EnvironmentBuilder` class to add a nice syntax for assembling an environment map from multiple sources.
3. Assemble the final map just before passing it to the `createContainerCmd`. This way I managed to avoid having to override methods to add values to the environment map. I think this makes it easier to follow what's going on in the code. There is one method for creating the shared variables and both the master and the agent add their own to those. 
I think the biggest improvement is the `ConsulContainer` where a new variable is added to the envVars map just to be used a few lines later by a method that delegates to the `AbstractContainer`, this was the inspiration for the change to create the map right where it get's used.