### PR TITLE
improved logging in test-framework/system-test

### DIFF
--- a/test-framework-docker/system-test/build.gradle
+++ b/test-framework-docker/system-test/build.gradle
@@ -9,10 +9,7 @@ dependencies {
     compile 'com.github.docker-java:docker-java:2.2.3'
     compile 'com.jayway.awaitility:awaitility:1.6.3'
 
-    compile 'org.slf4j:jcl-over-slf4j:1.7.12'
-    compile 'org.slf4j:log4j-over-slf4j:1.7.12'
     compile 'org.slf4j:jul-to-slf4j:1.7.12'
-
     compile 'org.slf4j:slf4j-api:1.7.12'
 
 }

--- a/test-framework-docker/system-test/src/test/java/com/containersolutions/mesoshelloworld/systemtest/DiscoverySystemTest.java
+++ b/test-framework-docker/system-test/src/test/java/com/containersolutions/mesoshelloworld/systemtest/DiscoverySystemTest.java
@@ -1,5 +1,10 @@
 package com.containersolutions.mesoshelloworld.systemtest;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import com.containersol.minimesos.cluster.MesosCluster;
 import com.containersol.minimesos.docker.DockerContainersUtil;
 import com.containersol.minimesos.junit.MesosClusterTestRule;
@@ -7,16 +12,13 @@ import com.containersolutions.mesoshelloworld.scheduler.Configuration;
 import com.github.dockerjava.api.model.Container;
 import com.jayway.awaitility.Awaitility;
 import com.jayway.awaitility.core.ConditionTimeoutException;
-import org.apache.log4j.Logger;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertTrue;
 
@@ -25,7 +27,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class DiscoverySystemTest {
 
-    public static final Logger LOGGER = Logger.getLogger(DiscoverySystemTest.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(DiscoverySystemTest.class);
 
     @ClassRule
     public static final MesosClusterTestRule RULE = MesosClusterTestRule.fromFile("src/test/resources/configFiles/minimesosFile-discoverySystemTest");

--- a/test-framework-docker/system-test/src/test/resources/logback-test.xml
+++ b/test-framework-docker/system-test/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration debug="false">
+
+	<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+		<target>System.out</target>
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}: %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="com.containersol.minimesos" level="debug"/>
+
+	<root level="warn">
+		<appender-ref ref="console" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
improved logging in test-framework/system-test
- removed log4j from classpath
- added explicit logging configuration (previosly no logs were visible during test run)