### PR TITLE
Prevent a partially downloaded script from running.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -5,6 +5,8 @@
 #
 # Uses the latest release, unless a version identifier is specified as a parameter of this script.
 
+{ # Prevent execution if the script is only partially downloaded
+
 command_exists() {
     command -v "$@" > /dev/null 2>&1
 }
@@ -40,3 +42,5 @@ else
 fi
 
 exit 0
+} # Prevent execution if the script is only partially downloaded
+

--- a/bin/install-version
+++ b/bin/install-version
@@ -3,6 +3,8 @@
 # This script is meant to be invoked with VERSION given as a parameter.
 # Installs the given version of minimesos on the box
 
+{ # Prevent execution if the script is only partially downloaded
+
 command_exists() {
     command -v "$@" > /dev/null 2>&1
 }
@@ -34,3 +36,5 @@ echo "Run the following command to add it to your executables path:" && echo
 echo "export PATH=\$PATH:$INSTALL_LOCATION"
 
 exit 0
+
+} # Prevent execution if the script is only partially downloaded


### PR DESCRIPTION
By wrapping the content of the script in '{', '}', sh will not start
executing any commands until the closing '}' is encountered.

<hr>
Proof:
```
$ cat test1.sh
echo hello world
MISSING STUFF

$ sh test1.sh 
hello world
test1.sh: line 2: MISSING: command not found

$ cat test2.sh 
{
echo hello world
MISSING STUFF

$ sh test2.sh 
test2.sh: line 4: syntax error: unexpected end of file
```