### PR TITLE
#433. There is no need to enforce --mapPortsToHost parameter on MAC

### DIFF
--- a/bin/minimesos
+++ b/bin/minimesos
@@ -38,16 +38,7 @@ pullImage() {
 }
 
 if [ "$#" -gt 0 -a "$1" = up ]; then
-
     pullImage "containersol/minimesos" ${MINIMESOS_TAG}
-
-    if [ "$(uname)" = "Darwin" ]; then
-        if [[ ${PARAMS} != *"--mapPortsToHost"* ]]; then
-        	echo "# You are running minimesos on OS X, enabling --mapPortsToHost"
-	        PARAMS="${PARAMS} --mapPortsToHost"
-	    fi
-    fi
-
 fi
 
 MINIMESOS_HOST_DIR="$(pwd)"


### PR DESCRIPTION
Mapping of ports is needed when docker-machine is used and docker host is not added to the routing table. This is not MAC specific