### PR TITLE
Use a base alpine image

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,13 +1,6 @@
-FROM debian:jessie-backports
-FROM openjdk:8-jre-alpine
+FROM alpine:3.5
 MAINTAINER Container Solutions BV <info@container-solutions.com>
 
-RUN apk add --update curl libstdc++&& \
-        rm -rf /var/cache/apk/*
-
-RUN curl https://get.docker.com/builds/Linux/x86_64/docker-1.12.0.tgz -o docker-1.12.0.tgz && \
-    tar xzf docker-1.12.0.tgz && \
-    mv docker/docker /usr/bin/docker && \
-    chmod +x /usr/bin/docker
+RUN apk add --update --no-cache docker openjdk8-jre-base
 
 ADD minimesos-cli.jar /usr/local/share/minimesos/minimesos-cli.jar


### PR DESCRIPTION
This patch change the base image for minimesos to alpine:3.5
Alpine is now packaging docker, no need to download it through curl
Install openjdk-jre-base instead of full version (save ~30MB)
Image size is reduced by about 20% (265MB to 215MB) this reduce
build and download time.