### PR TITLE
Ability to configure marathon start command

### DIFF
--- a/minimesos/src/main/groovy/com/containersol/minimesos/config/ConfigParser.groovy
+++ b/minimesos/src/main/groovy/com/containersol/minimesos/config/ConfigParser.groovy
@@ -28,7 +28,8 @@ class ConfigParser {
     private final List<String> ignoredProperties = ["class", "format"]
 
     private final Map<String, String> comments = [
-            "minimesos.marathon.apps": "Add 'app { marathonJson = \"<path or URL to JSON file>\" }' for every task you want to execute"
+            "minimesos.marathon.apps": "Add 'app { marathonJson = \"<path or URL to JSON file>\" }' for every task you want to execute",
+            "minimesos.marathon.cmd": "BEWARE: this option customize the marathon starting command, changing it can break the cluster"
     ]
 
     public ClusterConfig parse(String config) {

--- a/minimesos/src/main/groovy/com/containersol/minimesos/config/MarathonConfig.groovy
+++ b/minimesos/src/main/groovy/com/containersol/minimesos/config/MarathonConfig.groovy
@@ -7,12 +7,16 @@ public class MarathonConfig extends ContainerConfigBlock implements ContainerCon
     public static final String MARATHON_IMAGE = "mesosphere/marathon"
     public static final String MARATHON_IMAGE_TAG = "v1.3.5"
     public static final int MARATHON_PORT = 8080;
+    public static final String MARATHON_CMD = "--master zk://minimesos-zookeeper:2181/mesos --zk zk://minimesos-zookeeper:2181/marathon"
+
 
     List<AppConfig> apps = new ArrayList<>();
+    String cmd
 
     public MarathonConfig() {
         imageName = MARATHON_IMAGE
         imageTag = MARATHON_IMAGE_TAG
+        cmd = MARATHON_CMD
     }
 
     def app(@DelegatesTo(AppConfig) Closure cl) {

--- a/minimesos/src/main/java/com/containersol/minimesos/marathon/MarathonContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/marathon/MarathonContainer.java
@@ -12,6 +12,7 @@ import com.containersol.minimesos.integrationtest.container.AbstractContainer;
 import com.containersol.minimesos.docker.DockerClientFactory;
 import com.containersol.minimesos.docker.DockerContainersUtil;
 import com.containersol.minimesos.util.Environment;
+import com.containersol.minimesos.util.CollectionsUtils;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Ports;
@@ -134,7 +135,7 @@ public class MarathonContainer extends AbstractContainer implements Marathon {
         return DockerClientFactory.build().createContainerCmd(config.getImageName() + ":" + config.getImageTag())
                 .withName(getName())
                 .withExtraHosts("minimesos-zookeeper:" + this.zooKeeper.getIpAddress())
-                .withCmd("--master", "zk://minimesos-zookeeper:2181/mesos", "--zk", "zk://minimesos-zookeeper:2181/marathon")
+                .withCmd(CollectionsUtils.splitCmd(config.getCmd()))
                 .withExposedPorts(exposedPort)
                 .withPortBindings(portBindings);
     }

--- a/minimesos/src/main/java/com/containersol/minimesos/util/CollectionsUtils.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/util/CollectionsUtils.java
@@ -5,10 +5,15 @@ import com.containersol.minimesos.MinimesosException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Utilities for dealing with collections
  */
 public class CollectionsUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CollectionsUtils.class);
 
     private CollectionsUtils() {
         // do not allow creation of instances
@@ -28,6 +33,46 @@ public class CollectionsUtils {
 
         return typed;
 
+    }
+
+    /**
+     * This function split the cmd attribute in an array of String to make
+     * it consumable by the withCmd from docker-java.
+     *
+     * It ensures that quotes and double quotes are correctly handled,
+     * the split is performed on spaces.
+    */
+    public static String[] splitCmd(String cmd) {
+        String arg = "";
+        ArrayList<String> args = new ArrayList<String>();
+        ArrayList<Character> quotes = new ArrayList<Character>();
+
+        LOGGER.debug(String.format("Parsing cmd line: %s", cmd));
+        for (int i = 0; i < cmd.length(); i++){
+            char c = cmd.charAt(i);
+            if (c == ' ' && quotes.size() == 0) { // split command on spaces
+                args.add(arg);
+                arg = "";
+                continue;
+            } else if (c == '\'' || c == '"') { // feed state array on quote and double quotes
+                if (quotes.size() > 0 && quotes.get(0) == c) {
+                    quotes.remove(0);
+                } else {
+                    quotes.add(0, c);
+                }
+            }
+            arg += c;
+        }
+        // add last parsed elem
+        if (arg != "") {
+            args.add(arg);
+        }
+        // check unconsistent state
+        if (quotes.size() != 0) {
+            throw new MinimesosException("Marathon cmd config quotes are not closed properly");
+
+        }
+        return args.toArray(new String[args.size()]);
     }
 
 }

--- a/minimesos/src/test/java/com/containersol/minimesos/util/CollectionsUtilsTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/util/CollectionsUtilsTest.java
@@ -1,0 +1,47 @@
+package com.containersol.minimesos.util;
+
+import com.containersol.minimesos.MinimesosException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class CollectionsUtilsTest {
+
+    @Test(expected = MinimesosException.class)
+    public void testSplitCmd_uncoherentCommandLine() {
+        CollectionsUtils.splitCmd("foo bar='test");
+    }
+
+    @Test
+    public void testSplitCmd_cmdLineEmpty() {
+        assertArrayEquals(
+            CollectionsUtils.splitCmd(""),
+            new String[]{}
+        );
+    }
+
+    @Test
+    public void testSplitCmd_cmdLineNoQuotes() {
+        assertArrayEquals(
+            CollectionsUtils.splitCmd("foo bar baaz qux"),
+            new String[]{"foo", "bar", "baaz", "qux"}
+        );
+    }
+
+    @Test
+    public void testSplitCmd_cmdLineWithQuotes() {
+        assertArrayEquals(
+            CollectionsUtils.splitCmd("foo='bar baaz' qux"),
+            new String[]{"foo='bar baaz'", "qux"}
+        );
+    }
+
+    @Test
+    public void testSplitCmd_cmdLineWithDoubleQuotes() {
+        assertArrayEquals(
+            CollectionsUtils.splitCmd("foo=\"bar baaz\" qux"),
+            new String[]{"foo=\"bar baaz\"", "qux"}
+        );
+    }
+}


### PR DESCRIPTION
Add a cmd entry to the Marathon configuration block, this entry is passed
to the marathon container at starting time.
The command is parsed into an array of string before passing it to the withCmd
of docker-java.
Support quoted and double quoted arguments.

Close: #509