### PR TITLE
Add "minimesos logs" command

### DIFF
--- a/cli/src/integration-test/java/com/containersol/minimesos/main/CommandLogsTest.java
+++ b/cli/src/integration-test/java/com/containersol/minimesos/main/CommandLogsTest.java
@@ -115,6 +115,23 @@ public class CommandLogsTest {
     }
 
     @Test
+    public void TestUnexistingTask() throws UnsupportedEncodingException, URISyntaxException {
+        // Given
+        CommandLogs commandLogs = new CommandLogs(ps);
+        commandLogs.setRepository(repository);
+        commandLogs.setDownloader(downloader);
+        commandLogs.taskId = "doesn't exist";
+
+        // When
+        commandLogs.execute();
+
+        // Then
+        String result = outputStream.toString("UTF-8");
+        assertEquals("Cannot find task: 'doesn't exist'\n", result);
+
+    }
+
+    @Test
     public void TestStderr() throws UnsupportedEncodingException, URISyntaxException {
         // Given
         CommandLogs commandLogs = new CommandLogs(ps);

--- a/cli/src/integration-test/java/com/containersol/minimesos/main/CommandLogsTest.java
+++ b/cli/src/integration-test/java/com/containersol/minimesos/main/CommandLogsTest.java
@@ -1,0 +1,145 @@
+package com.containersol.minimesos.main;
+
+import com.containersol.minimesos.cluster.ClusterRepository;
+import com.containersol.minimesos.cluster.MesosCluster;
+import com.containersol.minimesos.cluster.MesosClusterFactory;
+import com.containersol.minimesos.mesos.MesosAgentContainer;
+import com.containersol.minimesos.mesos.MesosMasterContainer;
+import com.containersol.minimesos.state.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CommandLogsTest {
+
+    private final String slaveId = "de09c926-7be6-47c6-ab9a-6d1a2b32b642-S0";
+    private final String taskId = "http-ports-static-assigned-to-31002.0f732069-a1f2-11e7-97e0-0242ac110006";
+    private final String workDir = "/var/lib/mesos/agent-3039938407";
+    private final String frameworkId = "de09c926-7be6-47c6-ab9a-6d1a2b32b642-0000";
+    private final String runId = "fd7f7182-5ee8-47fc-a1c4-6928aeb1f769";
+    private final String agentServiceURL = "http://172.17.0.7:5051";
+
+    private final String PATH_FORMAT = "%s/slaves/%s/frameworks/%s/executors/%s/runs/%s";
+    private final String executorDirectory = String.format(PATH_FORMAT, workDir, slaveId, frameworkId, taskId, runId);
+
+    private final String EXPECTED_URL = "http://172.17.0.7:5051" +
+        "/files/download?path=" +
+        "%2Fvar%2Flib%2Fmesos" +
+        "%2Fagent-3039938407" +
+        "%2Fslaves%2Fde09c926-7be6-47c6-ab9a-6d1a2b32b642-S0" +
+        "%2Fframeworks%2Fde09c926-7be6-47c6-ab9a-6d1a2b32b642-0000" +
+        "%2Fexecutors%2Fhttp-ports-static-assigned-to-31002.0f732069-a1f2-11e7-97e0-0242ac110006" +
+        "%2Fruns%2Ffd7f7182-5ee8-47fc-a1c4-6928aeb1f769" +
+        "%2Fstderr\n";
+
+    private ByteArrayOutputStream outputStream;
+
+    private PrintStream ps;
+
+    @Before
+    public void initTest() {
+        outputStream = new ByteArrayOutputStream();
+        ps = new PrintStream(outputStream, true);
+    }
+
+    @Test
+    public void getSandboxURLTest() throws UnsupportedEncodingException, URISyntaxException {
+
+        State masterState = generateMasterState();
+        State agentState = generateAgentState();
+
+        MesosMasterContainer master = mock(MesosMasterContainer.class);
+        when(master.getState()).thenReturn(masterState);
+
+        MesosAgentContainer agent = mock(MesosAgentContainer.class);
+        when(agent.getState()).thenReturn(agentState);
+        when(agent.getServiceUrl()).thenReturn(new URI("http://172.17.0.7:5051"));
+
+        MesosCluster mesosCluster = mock(MesosCluster.class);
+        when(mesosCluster.getMaster()).thenReturn(master);
+        when(mesosCluster.getAgents()).thenReturn(Collections.singletonList(agent));
+
+        ClusterRepository repository = mock(ClusterRepository.class);
+        when(repository.loadCluster(any(MesosClusterFactory.class))).thenReturn(mesosCluster);
+
+        // Given
+        CommandLogs commandLogs = new CommandLogs(ps);
+        commandLogs.setRepository(repository);
+        commandLogs.taskId = taskId;
+
+        // When
+        commandLogs.execute();
+
+        // Then
+        String result = outputStream.toString("UTF-8");
+        assertEquals(EXPECTED_URL, result);
+    }
+
+    private State generateAgentState() {
+        State state = new State();
+        state.setId(slaveId);
+
+        Framework marathon = new Framework();
+        marathon.setName("marathon");
+        marathon.setId(frameworkId);
+
+        Executor executor = new Executor();
+        executor.setDirectory(executorDirectory);
+        executor.setId(taskId);
+        ArrayList<Executor> executors = new ArrayList<>();
+        executors.add(executor);
+        marathon.setExecutors(executors);
+
+        ArrayList<Framework> frameworks = new ArrayList<>();
+        frameworks.add(marathon);
+        state.setFrameworks(frameworks);
+
+        return state;
+    }
+
+    private State generateMasterState() {
+        State state = new State();
+        Framework marathon = new Framework();
+        marathon.setName("marathon");
+
+        Task task = new Task();
+        task.setName("weave-scope");
+        task.setState("TASK_RUNNING");
+        task.setId(taskId);
+        task.setSlaveId(slaveId);
+
+        Port port = new Port();
+        port.setNumber(4040);
+
+        Ports ports = new Ports();
+        ports.setPorts(singletonList(port));
+
+        Discovery discovery = new Discovery();
+        discovery.setPorts(ports);
+
+        task.setDiscovery(discovery);
+
+        ArrayList<Task> tasks = new ArrayList<>();
+        tasks.add(task);
+
+        marathon.setTasks(tasks);
+
+        ArrayList<Framework> frameworks = new ArrayList<>();
+        frameworks.add(marathon);
+        state.setFrameworks(frameworks);
+
+        return state;
+    }
+}

--- a/cli/src/integration-test/java/com/containersol/minimesos/main/CommandLogsTest.java
+++ b/cli/src/integration-test/java/com/containersol/minimesos/main/CommandLogsTest.java
@@ -6,6 +6,7 @@ import com.containersol.minimesos.cluster.MesosClusterFactory;
 import com.containersol.minimesos.mesos.MesosAgentContainer;
 import com.containersol.minimesos.mesos.MesosMasterContainer;
 import com.containersol.minimesos.state.*;
+import com.containersol.minimesos.util.Downloader;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class CommandLogsTest {
     private final String PATH_FORMAT = "%s/slaves/%s/frameworks/%s/executors/%s/runs/%s";
     private final String executorDirectory = String.format(PATH_FORMAT, workDir, slaveId, frameworkId, taskId, runId);
 
-    private final String EXPECTED_URL = "http://172.17.0.7:5051" +
+    private final String STDOUT_URL = "http://172.17.0.7:5051" +
         "/files/download?path=" +
         "%2Fvar%2Flib%2Fmesos" +
         "%2Fagent-3039938407" +
@@ -42,41 +43,63 @@ public class CommandLogsTest {
         "%2Fframeworks%2Fde09c926-7be6-47c6-ab9a-6d1a2b32b642-0000" +
         "%2Fexecutors%2Fhttp-ports-static-assigned-to-31002.0f732069-a1f2-11e7-97e0-0242ac110006" +
         "%2Fruns%2Ffd7f7182-5ee8-47fc-a1c4-6928aeb1f769" +
-        "%2Fstderr\n";
+        "%2Fstdout";
+
+    private final String STDERR_URL = "http://172.17.0.7:5051" +
+        "/files/download?path=" +
+        "%2Fvar%2Flib%2Fmesos" +
+        "%2Fagent-3039938407" +
+        "%2Fslaves%2Fde09c926-7be6-47c6-ab9a-6d1a2b32b642-S0" +
+        "%2Fframeworks%2Fde09c926-7be6-47c6-ab9a-6d1a2b32b642-0000" +
+        "%2Fexecutors%2Fhttp-ports-static-assigned-to-31002.0f732069-a1f2-11e7-97e0-0242ac110006" +
+        "%2Fruns%2Ffd7f7182-5ee8-47fc-a1c4-6928aeb1f769" +
+        "%2Fstderr";
 
     private ByteArrayOutputStream outputStream;
 
     private PrintStream ps;
 
+    private ClusterRepository repository;
+
+    private Downloader downloader;
+
+    private State masterState;
+
+    private State agentState;
+
     @Before
-    public void initTest() {
+    public void initTest() throws URISyntaxException {
         outputStream = new ByteArrayOutputStream();
         ps = new PrintStream(outputStream, true);
-    }
 
-    @Test
-    public void getSandboxURLTest() throws UnsupportedEncodingException, URISyntaxException {
-
-        State masterState = generateMasterState();
-        State agentState = generateAgentState();
+        masterState = generateMasterState();
+        agentState = generateAgentState();
 
         MesosMasterContainer master = mock(MesosMasterContainer.class);
         when(master.getState()).thenReturn(masterState);
 
         MesosAgentContainer agent = mock(MesosAgentContainer.class);
         when(agent.getState()).thenReturn(agentState);
-        when(agent.getServiceUrl()).thenReturn(new URI("http://172.17.0.7:5051"));
+        when(agent.getServiceUrl()).thenReturn(new URI(agentServiceURL));
 
         MesosCluster mesosCluster = mock(MesosCluster.class);
         when(mesosCluster.getMaster()).thenReturn(master);
         when(mesosCluster.getAgents()).thenReturn(Collections.singletonList(agent));
 
-        ClusterRepository repository = mock(ClusterRepository.class);
+        repository = mock(ClusterRepository.class);
         when(repository.loadCluster(any(MesosClusterFactory.class))).thenReturn(mesosCluster);
 
+        downloader = mock(Downloader.class);
+        when(downloader.getFileContentAsString(STDOUT_URL)).thenReturn("stdout file content");
+        when(downloader.getFileContentAsString(STDERR_URL)).thenReturn("stderr file content");
+    }
+
+    @Test
+    public void TestStdout() throws UnsupportedEncodingException, URISyntaxException {
         // Given
         CommandLogs commandLogs = new CommandLogs(ps);
         commandLogs.setRepository(repository);
+        commandLogs.setDownloader(downloader);
         commandLogs.taskId = taskId;
 
         // When
@@ -84,7 +107,31 @@ public class CommandLogsTest {
 
         // Then
         String result = outputStream.toString("UTF-8");
-        assertEquals(EXPECTED_URL, result);
+        assertEquals(
+            "[minimesos] Fetching 'stdout' of task 'http-ports-static-assigned-to-31002.0f732069-a1f2-11e7-97e0-0242ac110006'\n\n" +
+            "stdout file content\n",
+            result);
+
+    }
+
+    @Test
+    public void TestStderr() throws UnsupportedEncodingException, URISyntaxException {
+        // Given
+        CommandLogs commandLogs = new CommandLogs(ps);
+        commandLogs.setRepository(repository);
+        commandLogs.setDownloader(downloader);
+        commandLogs.taskId = taskId;
+        commandLogs.stderr = true;
+
+        // When
+        commandLogs.execute();
+
+        // Then
+        String result = outputStream.toString("UTF-8");
+        assertEquals(
+            "[minimesos] Fetching 'stderr' of task 'http-ports-static-assigned-to-31002.0f732069-a1f2-11e7-97e0-0242ac110006'\n\n" +
+                "stderr file content\n",
+            result);
     }
 
     private State generateAgentState() {
@@ -119,6 +166,8 @@ public class CommandLogsTest {
         task.setState("TASK_RUNNING");
         task.setId(taskId);
         task.setSlaveId(slaveId);
+        task.setFrameworkId(frameworkId);
+        task.setExecutorId("");
 
         Port port = new Port();
         port.setNumber(4040);

--- a/cli/src/main/java/com/containersol/minimesos/main/CommandLogs.java
+++ b/cli/src/main/java/com/containersol/minimesos/main/CommandLogs.java
@@ -1,0 +1,132 @@
+package com.containersol.minimesos.main;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.containersol.minimesos.cluster.ClusterRepository;
+import com.containersol.minimesos.cluster.MesosAgent;
+import com.containersol.minimesos.cluster.MesosCluster;
+import com.containersol.minimesos.mesos.MesosClusterContainersFactory;
+import com.containersol.minimesos.state.Executor;
+import com.containersol.minimesos.state.Framework;
+import com.containersol.minimesos.state.State;
+import com.containersol.minimesos.state.Task;
+import org.apache.http.client.utils.URIBuilder;
+
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+@Parameters(separators = "=", commandDescription = "Fetches the logs of the specified task")
+public class CommandLogs implements Command {
+
+    private PrintStream output = System.out; // NOSONAR
+
+    private ClusterRepository repository = new ClusterRepository();
+
+    @Parameter(names = "--task", description = "Substring of a task ID", required = true)
+    String taskId = null;
+
+    public CommandLogs(PrintStream output) {
+        this.output = output;
+    }
+
+    public CommandLogs() {
+        //NOSONAR
+    }
+
+    @Override
+    public boolean validateParameters() {
+        return isNotBlank(taskId);
+    }
+
+    @Override
+    public String getName() {
+        return "logs";
+    }
+
+    @Override
+    public void execute() {
+        if (taskId == null) {
+            return;
+        }
+
+        MesosCluster cluster = repository.loadCluster(new MesosClusterContainersFactory());
+
+        if (cluster == null) {
+            output.println("Minimesos cluster is not running");
+            return;
+        }
+
+        State masterState = cluster.getMaster().getState();
+        Task task = findTask(masterState, taskId);
+
+        if (task == null) {
+            output.println(String.format("Cannot find task: '%s'", taskId));
+            return;
+        }
+
+        MesosAgent agent = findAgent(cluster, task.getSlaveId());
+
+        if (agent == null) {
+            output.println(String.format("Cannot find agent: '%s'", task.getSlaveId()));
+            return;
+        }
+
+        State agentState = agent.getState();
+        Executor executor = findExecutor(agentState, task.getId());
+
+        if (executor == null) {
+            output.println(String.format("Cannot find executor: '%s'", task.getId()));
+            return;
+        }
+
+        String path = executor.getDirectory();
+
+        URIBuilder uriBuilder = new URIBuilder(agent.getServiceUrl())
+            .setPath("/files/download")
+            .addParameter("path", path + "/stderr");
+        try {
+            output.println(uriBuilder.build().toString());
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void setRepository(ClusterRepository repository) {
+        this.repository = repository;
+    }
+
+    private Task findTask(State state, String taskId) {
+        for (Framework framework : state.getFrameworks()) {
+            for (Task task: framework.getTasks()) {
+                if (task.getId().contains(taskId)) {
+                    return task;
+                }
+            }
+        }
+        return null;
+    }
+
+    private MesosAgent findAgent(MesosCluster cluster, String slaveId) {
+        for (MesosAgent agent : cluster.getAgents()) {
+            State agentState = agent.getState();
+            if (agentState.getId().equals(slaveId)) {
+                return agent;
+            }
+        }
+        return null;
+    }
+
+    private Executor findExecutor(State agentState, String taskId) {
+        for (Framework framework : agentState.getFrameworks()) {
+            for (Executor executor : framework.getExecutors()) {
+                if (executor.getId().equals(taskId)) {
+                    return  executor;
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/cli/src/main/java/com/containersol/minimesos/main/CommandLogs.java
+++ b/cli/src/main/java/com/containersol/minimesos/main/CommandLogs.java
@@ -21,7 +21,7 @@ import java.net.URISyntaxException;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
-@Parameters(separators = "=", commandDescription = "Fetches the logs of the specified task")
+@Parameters(separators = "=", commandDescription = "Fetches the stdout logs of the specified task")
 public class CommandLogs implements Command {
 
     private PrintStream output = System.out; // NOSONAR
@@ -33,7 +33,7 @@ public class CommandLogs implements Command {
     @Parameter(names = "--task", description = "Substring of a task ID", required = true)
     String taskId = null;
 
-    @Parameter(names = "--stderr", description = "Fetch the stderr logs")
+    @Parameter(names = "--stderr", description = "Fetch the stderr logs instead of stdout")
     Boolean stderr = false;
 
     public CommandLogs(PrintStream output) {

--- a/cli/src/main/java/com/containersol/minimesos/main/Main.java
+++ b/cli/src/main/java/com/containersol/minimesos/main/Main.java
@@ -56,6 +56,7 @@ public class Main {
         main.addCommand(new CommandInit());
         main.addCommand(new CommandPs());
         main.addCommand(new CommandVersion());
+        main.addCommand(new CommandLogs());
         try {
             int rc = main.run(args);
             if (EXIT_CODE_OK != rc) {

--- a/cli/src/test/java/com/containersol/minimesos/main/MainTest.java
+++ b/cli/src/test/java/com/containersol/minimesos/main/MainTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 
 import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
@@ -23,6 +24,7 @@ public class MainTest {
     private CommandState commandState;
     private CommandInstall commandInstall;
     private CommandUp commandUp;
+    private CommandLogs commandLogs;
 
     @Before
     public void before() {
@@ -45,6 +47,9 @@ public class MainTest {
         commandInstall = spy(new CommandInstall());
         doNothing().when(commandInstall).execute();
 
+        commandLogs = spy(new CommandLogs());
+        doNothing().when(commandLogs).execute();
+
         main = new Main();
         main.setOutput(ps);
         main.addCommand(commandUp);
@@ -52,6 +57,7 @@ public class MainTest {
         main.addCommand(commandInfo);
         main.addCommand(commandState);
         main.addCommand(commandInstall);
+        main.addCommand(commandLogs);
         main.addCommand(new CommandHelp());
 
     }
@@ -84,6 +90,19 @@ public class MainTest {
     public void testInstall() throws IOException {
         main.run(new String[]{"install", "--marathonFile", "bla.json"});
         verify(commandInstall).execute();
+    }
+
+    @Test
+    public void testLogs() throws IOException {
+        main.run(new String[]{"logs", "--task", "something"});
+        verify(commandLogs).execute();
+    }
+
+    @Test
+    public void testLogsNoParameter() throws IOException {
+        main.run(new String[]{"logs", "--task"});
+        String result = outputStream.toString("UTF-8");
+        assertTrue(result.contains("Usage: logs [options]"));
     }
 
     @Test

--- a/cli/src/test/java/com/containersol/minimesos/main/MainTest.java
+++ b/cli/src/test/java/com/containersol/minimesos/main/MainTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 
 import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosAgentContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/MesosAgentContainer.java
@@ -1,17 +1,25 @@
 package com.containersol.minimesos.mesos;
 
+import com.containersol.minimesos.MinimesosException;
 import com.containersol.minimesos.cluster.MesosAgent;
 import com.containersol.minimesos.cluster.MesosCluster;
 import com.containersol.minimesos.cluster.MesosDns;
 import com.containersol.minimesos.config.MesosAgentConfig;
 import com.containersol.minimesos.docker.DockerClientFactory;
+import com.containersol.minimesos.state.Executor;
+import com.containersol.minimesos.state.Framework;
+import com.containersol.minimesos.state.State;
+import com.containersol.minimesos.state.Task;
 import com.containersol.minimesos.util.ResourceUtil;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Link;
 import com.github.dockerjava.api.model.Volume;
+import org.apache.http.client.utils.URIBuilder;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/minimesos/src/main/java/com/containersol/minimesos/state/Executor.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/state/Executor.java
@@ -1,0 +1,26 @@
+package com.containersol.minimesos.state;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Executor {
+
+    private String id;
+    private String directory;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+}

--- a/minimesos/src/main/java/com/containersol/minimesos/state/Framework.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/state/Framework.java
@@ -27,6 +27,7 @@ public class Framework {
     private String role;
 
     private ArrayList<Task> tasks;
+    private ArrayList<Executor> executors = new ArrayList<>();
 
     public boolean isActive() {
         return active;
@@ -90,5 +91,13 @@ public class Framework {
 
     public void setTasks(ArrayList<Task> tasks) {
         this.tasks = tasks;
+    }
+
+    public ArrayList<Executor> getExecutors() {
+        return executors;
+    }
+
+    public void setExecutors(ArrayList<Executor> executors) {
+        this.executors = executors;
     }
 }

--- a/minimesos/src/main/java/com/containersol/minimesos/state/State.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/state/State.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class State {
 
+    private String id;
     private Map<String, String> flags = new HashMap<>();
 
     @JsonProperty("activated_slaves")
@@ -61,5 +62,13 @@ public class State {
 
     public String getVersion() {
         return version;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 }

--- a/minimesos/src/main/java/com/containersol/minimesos/state/Task.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/state/Task.java
@@ -13,6 +13,12 @@ public class Task {
     private String name;
     private String state;
 
+    @JsonProperty("framework_id")
+    private String frameworkId;
+
+    @JsonProperty("executor_id")
+    private String executorId;
+
     @JsonProperty("slave_id")
     private String slaveId;
 
@@ -40,6 +46,22 @@ public class Task {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getFrameworkId() {
+        return frameworkId;
+    }
+
+    public void setFrameworkId(String frameworkId) {
+        this.frameworkId = frameworkId;
+    }
+
+    public String getExecutorId() {
+        return executorId;
+    }
+
+    public void setExecutorId(String executorId) {
+        this.executorId = executorId;
     }
 
     public String getSlaveId() {

--- a/minimesos/src/main/java/com/containersol/minimesos/state/Task.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/state/Task.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Task {
 
+    private String id;
     private String name;
     private String state;
 
@@ -16,6 +17,14 @@ public class Task {
     private String slaveId;
 
     private Discovery discovery;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getState() {
         return state;

--- a/minimesos/src/main/java/com/containersol/minimesos/util/Downloader.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/util/Downloader.java
@@ -1,0 +1,27 @@
+package com.containersol.minimesos.util;
+
+import com.containersol.minimesos.MinimesosException;
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import org.apache.http.HttpStatus;
+
+import java.net.URI;
+
+public class Downloader {
+
+    public String getFileContentAsString(String url) throws MinimesosException {
+        HttpResponse<String> response = null;
+        try {
+            response = Unirest.get(url)
+                .header("content-type", "*/*")
+                .asString();
+        } catch (UnirestException e) {
+            throw new MinimesosException(String.format("Cannot fetch file '%s': '%s'", url, e.getMessage()));
+        }
+        if (response.getStatus() != HttpStatus.SC_OK) {
+            throw new MinimesosException(String.format("Cannot fetch file '%s': '%s'", url, response.getStatus()));
+        }
+        return response.getBody();
+    }
+}

--- a/minimesos/src/test/java/com/containersol/minimesos/ParseStateJSONTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/ParseStateJSONTest.java
@@ -307,5 +307,7 @@ public class ParseStateJSONTest {
         assertEquals("*", framework.getRole());
         assertEquals("0.22.1", parsedState.getVersion());
         assertEquals(0, framework.getExecutors().size());
+        assertEquals("29deeca9-0f28-4df7-af1d-14ae790044f6", framework.getTasks().get(0).getExecutorId());
+        assertEquals("20150907-122934-3858764204-5050-23-0000", framework.getTasks().get(0).getFrameworkId());
     }
 }

--- a/minimesos/src/test/java/com/containersol/minimesos/ParseStateJSONTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/ParseStateJSONTest.java
@@ -293,6 +293,7 @@ public class ParseStateJSONTest {
     @Test
     public void exampleStateJSONIsParsedCorrectly() throws JsonParseException, JsonMappingException {
         State parsedState = State.fromJSON(EXAMPLE_STATE_JSON);
+        assertEquals("20150907-122934-3858764204-5050-23", parsedState.getId());
         assertEquals(1, parsedState.getFrameworks().size());
         Framework framework = parsedState.getFramework("elasticsearch");
         assertNotNull(framework);

--- a/minimesos/src/test/java/com/containersol/minimesos/ParseStateJSONTest.java
+++ b/minimesos/src/test/java/com/containersol/minimesos/ParseStateJSONTest.java
@@ -306,5 +306,6 @@ public class ParseStateJSONTest {
         assertEquals("elasticsearch", framework.getName());
         assertEquals("*", framework.getRole());
         assertEquals("0.22.1", parsedState.getVersion());
+        assertEquals(0, framework.getExecutors().size());
     }
 }


### PR DESCRIPTION
# Add `minimesos logs` command
This PR implements the enhancement in issue #191 

# Dude, where are my logs?
In a Mesos cluster, the stdout/stderr of tasks are kept in a directory on the agent called _sandbox_. The content of this directory is exposed through the agent API via the `/files/download?path=...` endpoint. For more details, see the [Mesos documentation](http://mesos.apache.org/documentation/latest/sandbox/).

Here's an example:
```
$ curl http://172.17.0.8:5051/files/download?path=%2Fvar%2Flib%2Fmesos%2Fagent-1637653773%2Fslaves%2Ff6fbe47d-dbb4-477a-b855-4480b80ddb7b-S0%2Fframeworks%2Ff6fbe47d-dbb4-477a-b855-4480b80ddb7b-0000%2Fexecutors%2Fhttp-ports-static-assigned-to-31002.89452b29-a3bc-11e7-9371-0242ac110007%2Fruns%2F1c6733cd-0c94-476d-a56c-16d86f930495%2Fstdout
[...]
Registered docker executor on 172.17.0.8
Starting task http-ports-static-assigned-to-31002.89452b29-a3bc-11e7-9371-0242ac110007
Web Server started. Listening on 0.0.0.0:80
[...]
```

The general format is as follows:
```
<agentServiceUrl>/files/download?path=<workDir>/slaves/<slaveId>/framework/<frameworkId>/executors/<executorId>/runs/<runId>/<filename> 
```

# Access the logs programmatically
Generating the full URL to retrieve the stdout/stderr turned out to be trickier than expected. We need two parts:
1. the `agentServiceUrl` of the agent on which the task is running
2. the `path` to the sandbox

## Figure out `agentServiceUrl`
For `agentServiceUrl`, we match the `slaveId` in `Task` objects retrieved  in the Mesos master state with the `id` in each `MesosAgent.getState()`. Once found the agent, a simple `MesosAgent.getServiceUrl()` will give us what we need. This required adding parsing of `id` field in `State` objects.

## Figure out `path`
It would be tempting to build the `path` using the components already we already know (i.e. `slaveId`, `frameworkId`, ...). However, the `runId` is only exposed in the agent state. To retrieve this bit of information, we need to parse `frameworkId` and `executorId` in `Task` objects and the `directory` of the right `executor` in the `executors[]` section in the agent state. This is a stripped down example:

```json
{
  "id": "f6fbe47d-dbb4-477a-b855-4480b80ddb7b-S0", (slaveId)
  "flags": {},
  "frameworks": [
    {
      "id": "f6fbe47d-dbb4-477a-b855-4480b80ddb7b-0000", (frameworkId)
      "name": "marathon",
      "executors": [
        {
          "id": "http-ports-static-assigned-to-31002.89452b29-a3bc-11e7-9371-0242ac110007", (executorId/taskId)
          "container": "1c6733cd-0c94-476d-a56c-16d86f930495",
          ---> "directory": "/var/lib/mesos/agent-1637653773/slaves/f6fbe47d-dbb4-477a-b855-4480b80ddb7b-S0/frameworks/f6fbe47d-dbb4-477a-b855-4480b80ddb7b-0000/executors/http-ports-static-assigned-to-31002.89452b29-a3bc-11e7-9371-0242ac110007/runs/1c6733cd-0c94-476d-a56c-16d86f930495",

          "tasks": [
            {
              "id": "http-ports-static-assigned-to-31002.89452b29-a3bc-11e7-9371-0242ac110007",
              "name": "http-ports-static-assigned-to-31002",
              "framework_id": "f6fbe47d-dbb4-477a-b855-4480b80ddb7b-0000",
              "executor_id": "",
              "slave_id": "f6fbe47d-dbb4-477a-b855-4480b80ddb7b-S0",
              "state": "TASK_RUNNING"
            }
         ]
      }
   ]
}
```

# Download the content
Once we have the URL, I simply used Unirest to get the content of the file. This could eventually be improved in terms of memory usage. An idea could be using the `offset` and `length` and the endpoint `/files/read?path=...` described [here](http://mesos.apache.org/documentation/latest/sandbox/).

# CLI
Look!
```
$ minimesos --help
[...]
    logs      Fetches the stdout logs of the specified task
      Usage: logs [options]
        Options:
          --stderr
             Fetch the stderr logs instead of stdout
             Default: false
        * --task
             Substring of a task ID
[...]
```

# Tests
All the code was developed with a TDD approach. A full set of test is included. I also run all the test from the IDE and run a few manual test against a minimesos instance.