### PR TITLE
Feature/port bindings (fixes #543)

### DIFF
--- a/cli/src/main/java/com/containersol/minimesos/main/CommandUp.java
+++ b/cli/src/main/java/com/containersol/minimesos/main/CommandUp.java
@@ -29,7 +29,7 @@ public class CommandUp implements Command {
 
     private ClusterRepository repository = new ClusterRepository();
 
-    @Parameter(names = "--mapPortsToHost", description = "Map the Mesos and Marathon UI ports to the host level (we recommend to enable this on Mac (e.g. when using docker-machine) and disable on Linux).")
+    @Parameter(names = "--mapPortsToHost", description = "Map the Mesos, Marathon UI, Zookeeper and Consul ports to the host level (we recommend to enable this on Mac (e.g. when using docker-machine) and disable on Linux).")
     private Boolean mapPortsToHost = null;
 
     @Parameter(names = "--clusterConfig", description = "Path to file with cluster configuration. Defaults to minimesosFile")

--- a/minimesos/src/main/java/com/containersol/minimesos/mesos/ZooKeeperContainer.java
+++ b/minimesos/src/main/java/com/containersol/minimesos/mesos/ZooKeeperContainer.java
@@ -2,7 +2,6 @@ package com.containersol.minimesos.mesos;
 
 import com.containersol.minimesos.MinimesosException;
 import com.containersol.minimesos.cluster.MesosCluster;
-import com.containersol.minimesos.cluster.MesosDns;
 import com.containersol.minimesos.cluster.ZooKeeper;
 import com.containersol.minimesos.config.ZooKeeperConfig;
 import com.containersol.minimesos.integrationtest.container.AbstractContainer;
@@ -10,6 +9,7 @@ import com.containersol.minimesos.docker.DockerClientFactory;
 import com.containersol.minimesos.util.Environment;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.Ports;
 import org.apache.commons.lang.StringUtils;
 
 import java.net.URI;
@@ -47,9 +47,18 @@ public class ZooKeeperContainer extends AbstractContainer implements ZooKeeper {
 
     @Override
     protected CreateContainerCmd dockerCommand() {
+        int port = getServicePort();
+        ExposedPort exposedPort = ExposedPort.tcp(port);
+
+        Ports portBindings = new Ports();
+        if (getCluster().isMapPortsToHost()) {
+            portBindings.bind(exposedPort, Ports.Binding.bindPort(port));
+        }
+
         return DockerClientFactory.build().createContainerCmd(config.getImageName() + ":" + config.getImageTag())
             .withName(getName())
-            .withExposedPorts(new ExposedPort(ZooKeeperConfig.DEFAULT_ZOOKEEPER_PORT), new ExposedPort(2888), new ExposedPort(3888));
+            .withExposedPorts(new ExposedPort(ZooKeeperConfig.DEFAULT_ZOOKEEPER_PORT), new ExposedPort(2888), new ExposedPort(3888))
+            .withPortBindings(portBindings);
     }
 
     @Override


### PR DESCRIPTION
Added port bindings for Consul and Zookeeper, and updated the parameter description. Tested it on Ubuntu, now both ports work through localhost when using --mapPotsToHost.