### PR TITLE
Copy `minimesosFile` into the `minimesos-cli` container

### DIFF
--- a/bin/minimesos
+++ b/bin/minimesos
@@ -52,7 +52,10 @@ if [ ! -d "${MINIMESOS_DIR}" ]; then
     echo "# Created minimesos directory at ${MINIMESOS_DIR}."
 fi
 
-docker run --rm -v "${MINIMESOS_HOST_DIR}":"${MINIMESOS_HOST_DIR}" \
+
+DOCKER_CONTAINER=$(
+    docker create --rm \
+       -v "${MINIMESOS_HOST_DIR}":"${MINIMESOS_HOST_DIR}" \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v /sys/fs/cgroup:/sys/fs/cgroup \
        -i \
@@ -60,5 +63,10 @@ docker run --rm -v "${MINIMESOS_HOST_DIR}":"${MINIMESOS_HOST_DIR}" \
        --env MINIMESOS_OS="${MINIMESOS_OS}" \
        --entrypoint java \
        ${MINIMESOS_CLI_IMAGE}:${MINIMESOS_TAG} \
+       -Dminimesos.file="/minimesosFile" \
        -Dminimesos.host.dir="${MINIMESOS_HOST_DIR}" \
-       -jar /usr/local/share/minimesos/minimesos-cli.jar ${PARAMS}
+       -jar /usr/local/share/minimesos/minimesos-cli.jar ${PARAMS} \
+)
+
+docker cp ${MINIMESOS_HOST_DIR}/minimesosFile $DOCKER_CONTAINER:/minimesosFile
+docker start -a $DOCKER_CONTAINER

--- a/cli/src/main/java/com/containersol/minimesos/main/CommandUp.java
+++ b/cli/src/main/java/com/containersol/minimesos/main/CommandUp.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 @Parameters(separators = "=", commandDescription = "Create a minimesos cluster")
 public class CommandUp implements Command {
+    private static final String MINIMESOS_CLUSTER_CONFIG = "minimesos.file";
 
     private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(CommandUp.class);
 
@@ -59,6 +60,10 @@ public class CommandUp implements Command {
     }
 
     public String getClusterConfigPath() {
+        String sp = System.getProperty(MINIMESOS_CLUSTER_CONFIG);
+        if (sp != null) {
+            return sp;
+        }
         return clusterConfigPath;
     }
 


### PR DESCRIPTION
Previously, the `minimesos-cli` container relied on `minimesosFile` present
in the host's $MINIMESOS_HOST_DIR mounted inside the container. This works
for a local docker daemon, but fails with remote docker daemons (e.g.
docker-machine), because $DOCKER_CONTAINER:$MINIMESOS_HOST_DIR/minimesosFile
is a fresh directory if it does not exist in the [remote] host file system.

Now `minimesosFile` is copied into $DOCKER_CONTAINER:/minimesosFile and
minimesos-cli is configured with a new system property that points to this
location.

This should fix https://github.com/ContainerSolutions/minimesos/issues/546